### PR TITLE
flannel: wait for termination

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,12 @@ LABEL Vendor="Red Hat" \
       Architecture="x86_64" \
       Summary="Flannel is an etcd driven address (most commonly ip addresses) management agent"
 
-RUN yum-config-manager --enable rhel-7-server-extras-rpms || :
-RUN yum -y install flannel && yum clean all
-
 LABEL RUN /usr/bin/docker run -d --privileged --net=host \$OPT1 -v /usr/lib/systemd/system/docker.service.d:/usr/lib/systemd/system/docker.service.d -v /var/run:/var/run --name \$NAME \$IMAGE \$OPT2 \$OPT3
 
-ADD flanneld-run.sh flanneld-docker-env.sh /usr/bin/
+RUN yum-config-manager --enable rhel-7-server-extras-rpms || :
+RUN yum --enablerepo=rhel-7-server-extras-rpms -y install flannel && yum clean all
+
+ADD flanneld-run.sh /usr/bin/
 
 # System container files
 ADD tmpfiles.template service.template manifest.json config.json.template /exports/

--- a/config.json.template
+++ b/config.json.template
@@ -153,9 +153,9 @@
                         ]
                 },
                 {
+			"source": "${RUN_DIRECTORY}/${NAME}",
                         "destination": "/run/flannel",
                         "type": "bind",
-			"source": "${RUN_DIRECTORY}/${NAME}",
                         "options": [
                                 "rw",
                                 "rbind",

--- a/flanneld-docker-env.sh
+++ b/flanneld-docker-env.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-while true
-do
-  [ -f /run/flannel/subnet.env ] && break
-  sleep 2
-done
-
-/usr/libexec/flannel/mk-docker-opts.sh -k DOCKER_NETWORK_OPTIONS -d /run/flannel/docker

--- a/flanneld-run.sh
+++ b/flanneld-run.sh
@@ -2,8 +2,19 @@
 
 # Create flannel.conf for docker service
 echo "[Service]" > /etc/systemd/system/docker.service.d/flannel.conf
-echo "EnvironmentFile=-/run/flannel/docker" >> /etc/systemd/system/docker.service.d/flannel.conf
+echo "EnvironmentFile=-/run/$NAME/docker" >> /etc/systemd/system/docker.service.d/flannel.conf
 
-/usr/bin/flanneld-docker-env.sh &
+# Ensure this file doesn't already exist.
+rm -f run/flannel/subnet.env
 
-exec /usr/bin/flanneld
+/usr/bin/flanneld &
+child=$!
+
+while test \! -e /run/flannel/subnet.env
+do
+    sleep 0.1
+done
+
+/usr/libexec/flannel/mk-docker-opts.sh -k DOCKER_NETWORK_OPTIONS -d /run/flannel/docker
+
+wait $child

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,8 @@
     "defaultValues": {
 	"FLANNELD_ETCD_PREFIX": "/atomic.io/network",
 	"FLANNELD_ETCD_ENDPOINTS": "http://127.0.0.1:2379",
-	"AFTER": "etcd.service"
+	"AFTER": "etcd.service",
+	"REQUIRED_BY": "docker.service"
     }
 }
 

--- a/service.template
+++ b/service.template
@@ -9,9 +9,11 @@ Before=docker.service
 [Service]
 ExecStart=$EXEC_START
 ExecStop=$EXEC_STOP
+ExecStartPost=/usr/bin/sh -c "while test \! -s ${RUN_DIRECTORY}/${NAME}/docker; do sleep 0.1; done"
 Restart=on-failure
 WorkingDirectory=$DESTDIR
 RuntimeDirectory=${NAME}
 
 [Install]
 WantedBy=multi-user.target
+RequiredBy=$REQUIRED_BY


### PR DESCRIPTION
on systemctl start $SERVICE_NAME waits that the network is
configured.

Do not leave a zombie process.

Tested both on RHELAH and Fedora

Signed-off-by: Giuseppe Scrivano gscrivan@redhat.com
